### PR TITLE
Struct field rename with `xmlrpc` tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 0.x.y
 
+Improvements:
+
+* Ability to remap struct member names to via `xmlrpc` tags (#47)
+
+Library is now built against Go 1.19
+
 ## 0.3.0
 
 Improvements:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ import(
 
 func main() {
     client, _ := xmlrpc.NewClient("https://bugzilla.mozilla.org/xmlrpc.cgi")
-
+    defer client.Close()
+	
     result := &struct {
         BugzillaVersion struct {
             Version string
@@ -65,6 +66,36 @@ Response is decoded following similar rules to argument encoding.
 * Order of fields is important.
 * Outer struct should contain exported field for each response parameter.
 * Structs may contain pointers - they will be initialized if required.
+
+### Field renaming
+
+XML-RPC specification does not necessarily specify any rules for struct's member names. Some services allow struct member names to include characters not compatible with standard Go field naming.
+To support these use-cases, it is possible to remap the field by use of struct tag `xmlrpc`. 
+
+For example, if a response value is a struct that looks like this:
+
+```xml
+<struct>
+    <member>
+        <name>stringValue</name>
+        <value><string>bar</string></value>
+    </member>
+    <member>
+        <name>2_numeric.Value</name>
+        <value><i4>2</i4></value>
+    </member>
+</struct>
+```
+
+it would be impossible to map the second value to a Go struct with a field `2_numeric.Value` as it's not valid in Go.
+Instead, we can map it to any valid field as follows:
+
+```go
+v := &struct {
+    StringValue string
+    SecondNumericValue string `xmlrpc:"2_numeric.Value"`
+}{}
+```
 
 ## Building
 

--- a/encode.go
+++ b/encode.go
@@ -198,8 +198,11 @@ func (e *StdEncoder) encodeStruct(w io.Writer, val interface{}) error {
 
 		fieldType := reflect.TypeOf(val).Field(i)
 		fieldName := fieldType.Name
-		if fieldType.Tag.Get("xml") != "" {
-			fieldName = fieldType.Tag.Get("xml")
+		tag := fieldType.Tag
+		if tag.Get("xml") != "" {
+			fieldName = tag.Get("xml")
+		} else if tag.Get("xmlrpc") != "" {
+			fieldName = tag.Get("xmlrpc")
 		}
 		_, _ = fmt.Fprintf(w, "<member><name>%s</name>", fieldName)
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -118,6 +118,40 @@ func TestStdEncoder_Encode(t *testing.T) {
 			expect: `<methodCall><methodName>myMethod</methodName><params><param><value><string>&lt;div class=&#34;whitespace&#34;&gt;&amp;nbsp;&lt;/div&gt;</string></value></param></params></methodCall>`,
 			err:    nil,
 		},
+		{
+			name:       "Struct args - encoded",
+			methodName: "myMethod",
+			args: &struct {
+				MyStruct struct {
+					String string
+				}
+			}{
+				MyStruct: struct {
+					String string
+				}{
+					String: "foo",
+				},
+			},
+			expect: `<methodCall><methodName>myMethod</methodName><params><param><value><struct><member><name>String</name><value><string>foo</string></value></member></struct></value></param></params></methodCall>`,
+			err:    nil,
+		},
+		{
+			name:       "Struct args renamed - encoded",
+			methodName: "myMethod",
+			args: &struct {
+				MyStruct struct {
+					String string `xmlrpc:"2-.Arg"`
+				}
+			}{
+				MyStruct: struct {
+					String string `xmlrpc:"2-.Arg"`
+				}{
+					String: "foo",
+				},
+			},
+			expect: `<methodCall><methodName>myMethod</methodName><params><param><value><struct><member><name>2-.Arg</name><value><string>foo</string></value></member></struct></value></param></params></methodCall>`,
+			err:    nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/testdata/response_struct.xml
+++ b/testdata/response_struct.xml
@@ -20,6 +20,10 @@
                         <name>WoBleBobble2</name>
                         <value><int>34</int></value>
                     </member>
+                    <member>
+                        <name>2</name>
+                        <value><int>3</int></value>
+                    </member>
                 </struct>
             </value>
         </param>


### PR DESCRIPTION
Adding ability to remap XMLRPC struct member names with `xmlrpc` tags.

XML-RPC specification does not necessarily specify any rules for struct's member names. Some services allow struct member names to include characters not compatible with standard Go field naming.

For example, if a response value is a struct that looks like this:

```xml
<struct>
    <member>
        <name>stringValue</name>
        <value><string>bar</string></value>
    </member>
    <member>
        <name>2_numeric.Value</name>
        <value><i4>2</i4></value>
    </member>
</struct>
```

it would be impossible to map the second value to a Go struct with a field `2_numeric.Value` as it's not valid in Go.
Instead, we can map it to any valid field as follows:

```go
v := &struct {
    StringValue string
    SecondNumericValue string `xmlrpc:"2_numeric.Value"`
}{}
```

Fixes #47