### PR TITLE
Support decoding of a struct nested into an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.2
+
+Bugfixes:
+* Decoding a `<struct>` that is nested in `<array>` with variable types (e.g mix of ints, bool, string and structs) (#84).
+Structs will be decoded into a `map[string]any` type, as it's not possible to decode.
+
 ## 0.5.1
 
 Bugfixes:

--- a/decode_test.go
+++ b/decode_test.go
@@ -622,6 +622,20 @@ func Test_structMemberToFieldName(t *testing.T) {
 	}
 }
 
+func Test_github(t *testing.T) {
+	dec := &StdDecoder{}
+	decodeTarget := struct {
+		Array []any
+	}{}
+
+	err := dec.DecodeRaw(loadTestFile(t, "response_array_mixed_with_struct.xml"), &decodeTarget)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(decodeTarget.Array))
+	require.Equal(t, 200, decodeTarget.Array[0])
+	require.Equal(t, "OK", decodeTarget.Array[1])
+	require.Equal(t, "OK", decodeTarget.Array[2].(map[string]any)["status"])
+}
+
 func loadTestFile(t *testing.T, name string) []byte {
 	path := filepath.Join("testdata", name) // relative path
 

--- a/testdata/response_array_mixed_with_struct.xml
+++ b/testdata/response_array_mixed_with_struct.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<methodResponse>
+    <params>
+        <param>
+            <value>
+                <array>
+                    <data>
+                        <value>
+                            <i4>200</i4>
+                        </value>
+                        <value>OK</value>
+                        <value>
+                            <struct>
+                                <member>
+                                    <name>status</name>
+                                    <value>OK</value>
+                                </member>
+                                <member>
+                                    <name>contact</name>
+                                    <value>&lt;sip:raf@192.168.164.128:5060&gt;;expires=60</value>
+                                </member>
+                            </struct>
+                        </value>
+                    </data>
+                </array>
+            </value>
+        </param>
+    </params>
+</methodResponse>


### PR DESCRIPTION
Fixes an issues where responses that have an outer array with a nested struct and other mixed types would not be decoded correctly, throwing a panic.

Example response:
```xml
<methodResponse>
  <params>
    <param>
      <value>
        <array>
          <data>
            <value>
              <i4>200</i4>
            </value>
            <value>OK</value>
            <value>
              <struct>
                <member>
                  <name>status</name>
                  <value>OK</value>
                </member>
                <member>
                  <name>contact</name>
                  <value>&lt;sip:raf@192.168.164.128:5060&gt;;expires=60</value>
                </member>
              </struct>
            </value>
          </data>
        </array>
      </value>
    </param>
  </params>
</methodResponse>
```

Correct way of mapping this response is to
```go
struct{
    Array []any
}
```

Main issue with decoding this response prior to this PR, would be that `any` in array type is not assignable as is with decoded types.
This PR changes the logic to detect if an interface is mapped when attempting to decode a `<struct>` and assign a `map[string]any` to the field instead.

Fixes #84 