### PR TITLE
Added support to encode maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ Arguments to the remote RPC method are passed on as a `*struct`. This struct is 
 * Order of fields in struct type matters - fields are taken in the order they are defined on the **type**.
 * Numbers are to be specified as `int` (encoded as `<int>`) or `float64` (encoded as `<double>`)
 * Both pointer and value references are accepted (pointers are followed to actual values)
+* `map[string]any` types are accepted and encoded into `<struct>`
+
+**Shortcut:**  
+If a single `<struct>` argument is expected for the RPC method call, it is sometimes more convenient to pass a `map[string]any` as an argument without wrapping into `struct{}`. This `map[string]any` will be encoded into a single `<struct>` argument with `<member>` elements for each key-value pair.
+No other key types are supported and neither is it possible to apply this approach with multiple arguments (or other types).
+
+**Order preservation:**  
+As per XML-RPC specification, the order of `<member>` elements in `<struct>` is not defined. When using maps, order of members in a struct is undeterministic, thus it is not guaranteed that the order of `<member>` elements will match the order of keys in the map (due to Go not preserving the order of keys).
+To preserve the order, use a struct type with fields defined in the desired order (order is inherited from the struct type itself, not the instance).
 
 ### Response decoding
 

--- a/encode.go
+++ b/encode.go
@@ -34,36 +34,60 @@ func (e *StdEncoder) Encode(w io.Writer, methodName string, args interface{}) er
 func (e *StdEncoder) encodeArgs(w io.Writer, args interface{}) error {
 	// Allows reading both pointer and value-structs
 	elem := reflect.Indirect(reflect.ValueOf(args))
+
+	switch elem.Kind() {
+	case reflect.Map:
+		return e.encodeBareMapArgs(w, elem)
+	case reflect.Struct:
+		return e.encodeStructArgs(w, elem)
+	default:
+		return fmt.Errorf("unsupported argument type %s - use stuct{} wrapper with exported fields (or map[string]{} if single <struct> param is expected) ", elem.Kind().String())
+	}
+}
+
+func (e *StdEncoder) encodeStructArgs(w io.Writer, elem reflect.Value) error {
 	numFields := elem.NumField()
-
-	if numFields > 0 {
-		hasExportedFields := false
-
-		for fN := 0; fN < numFields; fN++ {
-			field := elem.Field(fN)
-			if !field.CanInterface() {
-				continue
-			}
-
-			// If this is first exported field - print out <params> tag
-			if !hasExportedFields {
-				hasExportedFields = true
-				_, _ = fmt.Fprint(w, "<params>")
-			}
-
-			_, _ = fmt.Fprint(w, "<param>")
-			if err := e.encodeValue(w, field.Interface()); err != nil {
-				return fmt.Errorf("cannot encode argument '%s': %w", elem.Type().Field(fN).Name, err)
-			}
-			_, _ = fmt.Fprint(w, "</param>")
-		}
-
-		// Only write closing </params> tag if at least one exported field is found
-		if hasExportedFields {
-			_, _ = fmt.Fprint(w, "</params>")
-		}
+	if numFields == 0 {
+		return nil
 	}
 
+	hasExportedFields := false
+	for fN := 0; fN < numFields; fN++ {
+		field := elem.Field(fN)
+		if !field.CanInterface() {
+			continue
+		}
+
+		// If this is first exported field - print out <params> tag
+		if !hasExportedFields {
+			hasExportedFields = true
+			_, _ = fmt.Fprint(w, "<params>")
+		}
+
+		_, _ = fmt.Fprint(w, "<param>")
+		if err := e.encodeValue(w, field.Interface()); err != nil {
+			return fmt.Errorf("cannot encode argument '%s': %w", elem.Type().Field(fN).Name, err)
+		}
+		_, _ = fmt.Fprint(w, "</param>")
+	}
+
+	// Only write closing </params> tag if at least one exported field is found
+	if hasExportedFields {
+		_, _ = fmt.Fprint(w, "</params>")
+	}
+
+	return nil
+}
+
+func (e *StdEncoder) encodeBareMapArgs(w io.Writer, elem reflect.Value) error {
+	if elem.Type().Key().Kind() != reflect.String {
+		return fmt.Errorf("unsupported type %s for bare map key, only string keys are supported", elem.Type().Key().Kind().String())
+	}
+	_, _ = fmt.Fprint(w, "<params><param>")
+	if err := e.encodeValue(w, elem.Interface()); err != nil {
+		return fmt.Errorf("cannot encode bare map argument: %w", err)
+	}
+	_, _ = fmt.Fprint(w, "</param></params>")
 	return nil
 }
 


### PR DESCRIPTION
Added support to encode maps as parameters, simplifies integrating with Odoo XMLRPC API for example.