### PR TITLE
Support charset transform if necessary

### DIFF
--- a/decode_response.go
+++ b/decode_response.go
@@ -1,6 +1,11 @@
 package xmlrpc
 
-import "encoding/xml"
+import (
+	"bytes"
+	"encoding/xml"
+
+	"golang.org/x/net/html/charset"
+)
 
 // Response is the basic parsed object of the XML-RPC response body.
 // While it's not convenient to use this object directly - it contains all the information needed to unmarshal into other data-types.
@@ -13,7 +18,9 @@ type Response struct {
 // It relies on XML Unmarshaler and if it fails - error is returned.
 func NewResponse(body []byte) (*Response, error) {
 	response := &Response{}
-	if err := xml.Unmarshal(body, response); err != nil {
+	dec := xml.NewDecoder(bytes.NewReader(body))
+	dec.CharsetReader = charset.NewReaderLabel
+	if err := dec.Decode(response); err != nil {
 		return nil, err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,15 @@
 module alexejk.io/go-xmlrpc
 
-go 1.21
+go 1.25.3
 
-require github.com/stretchr/testify v1.10.0
+require (
+	github.com/stretchr/testify v1.10.0
+	golang.org/x/net v0.46.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/text v0.30.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/net v0.46.0 h1:giFlY12I07fugqwPuWJi68oOnpfqFnJIJzaIIm2JVV4=
+golang.org/x/net v0.46.0/go.mod h1:Q9BGdFy1y4nkUwiLvT5qtyhAnEHgnQ/zd8PfU6nc210=
+golang.org/x/text v0.30.0 h1:yznKA/E9zq54KzlzBEAWn1NXSQ8DIp/NYMy88xJjl4k=
+golang.org/x/text v0.30.0/go.mod h1:yDdHFIX9t+tORqspjENWgzaCVXgk0yYnYuSZ8UzzBVM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
The service I needed to connect to wasn't using utf-8, so I added the autocharset transform from the std library x.

I don't think you actually need to update the go version in go.mod, but I have my git require a clean govulncheck to commit, so I updated it to make it happy.

I didn't add a test case or anything, but thought I'd send ti along anyhow.  