### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -6,6 +6,10 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v9
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/alexejk/go-xmlrpc/security/code-scanning/1](https://github.com/alexejk/go-xmlrpc/security/code-scanning/1)

Generally, the fix is to explicitly define `permissions` for the `GITHUB_TOKEN` in each workflow/job so that it has only the scopes it needs. For a stale-issues workflow that labels and closes issues and PRs, the job must have `issues: write` and `pull-requests: write`. It does not need broader repository write access, so `contents` can be restricted to `read`.

The best fix here is to add a `permissions` block to the `stale` job in `.github/workflows/stale-issues.yml`, just under `runs-on: ubuntu-latest`. This block should set `contents: read`, `issues: write`, and `pull-requests: write`. That aligns with the CodeQL suggested minimal starting point while still honoring least privilege (no extra write scopes). No imports or additional methods are needed since this is a GitHub Actions YAML workflow; we only modify the YAML job definition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
