### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@master


### PR DESCRIPTION
Potential fix for [https://github.com/alexejk/go-xmlrpc/security/code-scanning/2](https://github.com/alexejk/go-xmlrpc/security/code-scanning/2)

In general, the fix is to explicitly define a `permissions` block for the workflow or for the specific job so that the GITHUB_TOKEN only has the minimal required scopes. Since this workflow’s `build` job creates a GitHub Release using `softprops/action-gh-release`, it needs write access to repository contents, but does not obviously require broader permissions (issues, pull-requests, etc.).

The best targeted fix without changing existing behavior is to add a `permissions` block under the `build` job (indented to align with `runs-on:`). This keeps the change localized and communicates clearly which job requires which permissions. For releasing, GitHub’s documented requirement is `contents: write`, so we will set that and nothing else. Concretely, in `.github/workflows/release.yml`, add:

```yaml
permissions:
  contents: write
```

between `runs-on: ubuntu-latest` and `steps:` in the `build` job. No imports or code changes elsewhere are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
